### PR TITLE
Graceful shutdown

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -47,7 +47,7 @@ Given no arguments, builds all packages. Otherwise, builds only the specified pa
 		// TODO: Parallelism.
 		for _, pkg := range packages {
 			buildOpts.Package = pkg
-			if err := internal.Build(repo, buildOpts); err != nil {
+			if err := internal.Build(cmd.Context(), repo, buildOpts); err != nil {
 				return err
 			}
 		}

--- a/internal/build.go
+++ b/internal/build.go
@@ -172,7 +172,7 @@ func (proc *funcProcess) Start() error {
 	return proc.start()
 }
 
-func (proc *funcProcess) Kill() error {
+func (proc *funcProcess) Stop() error {
 	return nil
 }
 

--- a/internal/build.go
+++ b/internal/build.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -17,7 +18,7 @@ type BuildOptions struct {
 	Watch   bool
 }
 
-func Build(repo *Repository, opts BuildOptions) error {
+func Build(ctx context.Context, repo *Repository, opts BuildOptions) error {
 	pkg := opts.Package
 
 	packageDir := path.Join(repo.OutDir, "dist", pkg.Name)
@@ -161,7 +162,7 @@ void (async () => {
 				},
 			}
 		},
-	}.Run()
+	}.Run(ctx)
 }
 
 type funcProcess struct {

--- a/internal/run.go
+++ b/internal/run.go
@@ -18,6 +18,7 @@
 package internal
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -40,7 +41,7 @@ type RunOptions struct {
 }
 
 // Status code may be returned within an exec.ExitError return value.
-func Run(repo *Repository, opts RunOptions) error {
+func Run(ctx context.Context, repo *Repository, opts RunOptions) error {
 	if err := EnsureTmp(repo); err != nil {
 		return err
 	}
@@ -124,7 +125,7 @@ if (typeof main === 'function') {
 
 			return &cmdProcess{cmd: node}
 		},
-	}.Run()
+	}.Run(ctx)
 }
 
 type cmdProcess struct {


### PR DESCRIPTION
This PR does 3 things:

- Cause the child process to be stopped with SIGTERM instead of SIGKILL. SIGKILL is still sent if the process has not stopped after a fixed period.
- Start the child process in its own process group so that stopping the child will also stop any of its owned processes.
- Intercept SIGKILL/SIGTERM in uni itself and trigger a shutdown of its child process

Resolves #10 